### PR TITLE
Fix on PackageInstaller and ProviderCreator

### DIFF
--- a/src/Rtablada/PackageInstaller/PackageInstaller.php
+++ b/src/Rtablada/PackageInstaller/PackageInstaller.php
@@ -100,6 +100,7 @@ class PackageInstaller
 			$content = str_replace('(', "(\n\t", $content);
 			$content = str_replace(')', "\n\t)", $content);
 			$content = str_replace("\n  ", "\n\t\t", $content);
+			$content = str_replace("array (", "array(", $content);
 		}
 
 		return $content;

--- a/src/Rtablada/PackageInstaller/ProviderCreator.php
+++ b/src/Rtablada/PackageInstaller/ProviderCreator.php
@@ -32,7 +32,7 @@ class ProviderCreator
 	{
 		if ($this->file->exists($path)) {
 			$contents = $this->file->get($path);
-			$contents = createValidJsonWithSlashes($contents);
+			$contents = $this->createValidJsonWithSlashes($contents);
 			return $this->provider->buildFromJson($contents);
 		}
 


### PR DESCRIPTION
Hello,
I find two errors :
- in ProviderCreator, the "this" for calling of createValidJsonWithSlashe()
- in PackageInstaller, because var_export() returns "array (", and we need "array("
