### PR TITLE
Follow composer convention to require a package with its version

### DIFF
--- a/src/Rtablada/PackageInstaller/PackageRequireCommand.php
+++ b/src/Rtablada/PackageInstaller/PackageRequireCommand.php
@@ -37,7 +37,7 @@ class PackageRequireCommand extends Command {
 	 */
 	public function fire()
 	{
-		passthru('composer require ' . $this->argument('packageName'));
+		passthru('composer require ' . $this->argument('package'));
 	}
 
 	/**
@@ -48,7 +48,7 @@ class PackageRequireCommand extends Command {
 	protected function getArguments()
 	{
 		return array(
-			array('packageName', InputArgument::REQUIRED, 'Name of the composer package to be installed.'),
+			array('package', InputArgument::REQUIRED, 'Name of the composer package and its version constraint to be installed.'),
 		);
 	}
 


### PR DESCRIPTION
E.g. 
- `php artisan package:install efficiently/authority-controller:1.2.*`
- `php artisan package:install efficiently/authority-controller=1.2.*`
- `php artisan package:install "efficiently/authority-controller 1.2.*"`

Fix issue #12 
