### PR TITLE
[important!] Compatibility with Laravel 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "illuminate/console": "~4",
         "illuminate/filesystem": "~4",
         "illuminate/config": "~4",
-        "knplabs/packagist-api": "dev-master"
+        "knplabs/packagist-api": "v1.1"
     },
     "require-dev": {
         "mockery/mockery": "0.8.*"
@@ -27,5 +27,5 @@
             "Rtablada\\PackageInstaller": "src/"
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "stable"
 }


### PR DESCRIPTION
Laravel 4.1 ships with composer's `"minimum-stability": "stable"` and current package-installer requirements are not compatible with it.
This commit changes requirements to make package work with L4.1
